### PR TITLE
Error fetching content type backup messages

### DIFF
--- a/src/core/exporter.py
+++ b/src/core/exporter.py
@@ -670,7 +670,7 @@ class DiscordExporter:
                             "filename": filename,
                             "size": actual_size,
                             "url": str(url),
-                            "content_type": content_type or in_pool["content_type"],
+                            "content_type": content_type or in_pool["mime_type"],
                             "local_hash": file_hash
                         }
                 


### PR DESCRIPTION
Intermediate Fix adding to my last one, the error appeared on more occasions apart from this one (namely when writing or reading the media_pool database table), any access to the media_pool has to be made through mime_type instead of content_type.