### PR TITLE
Fixed a bug where permissions were not propagated to fluxer roles

### DIFF
--- a/src/fluxer/roles_permissions.py
+++ b/src/fluxer/roles_permissions.py
@@ -132,8 +132,8 @@ async def sync_permissions(context: MigrationContext, progress_callback: Callabl
 async def migrate_roles(context: MigrationContext, progress_callback: Callable[[str, int, int], Awaitable[None]] | None = None, force: bool = False) -> list[str]:
     """Copies roles and their baseline permissions. Returns a list of cloned role names."""
     # Sort roles by position to respect Discord hierarchy
-    roles = sorted(await context.discord_reader.get_roles(), key=lambda r: r.position)
-    
+    roles = sorted(await context.discord_reader.get_roles(), key=lambda r: r.position, reverse=True)
+
     if not force:
         roles = [r for r in roles if not context.state.get_fluxer_role_id(str(r.id))]
 

--- a/src/fluxer/roles_permissions.py
+++ b/src/fluxer/roles_permissions.py
@@ -148,11 +148,13 @@ async def migrate_roles(context: MigrationContext, progress_callback: Callable[[
             break
             
         logger.debug(f"Creating role: {role.name}")
+        # No permission mapping nescessary since fluxer uses the same permission map as discord
         fluxer_id = await context.fluxer_writer.create_role(
             name=role.name,
             color=role.color.value,
             hoist=role.hoist,
             mentionable=role.mentionable,
+            permissions=role.permissions.value,
             position=role.position
         )
         if fluxer_id:

--- a/src/fluxer/writer.py
+++ b/src/fluxer/writer.py
@@ -388,7 +388,7 @@ class FluxerWriter:
             print(f"Failed to send marker: {e}")
             return None
 
-    async def create_role(self, name: str, color: int, hoist: bool, mentionable: bool, position: Optional[int] = None) -> str:
+    async def create_role(self, name: str, color: int, hoist: bool, mentionable: bool, permissions: int, position: Optional[int] = None) -> str:
         """
         Creates a new role in the Fluxer community.
         Returns the new Fluxer role ID.
@@ -402,6 +402,7 @@ class FluxerWriter:
                 color=color,
                 hoist=hoist,
                 mentionable=mentionable,
+                permissions=permissions,
                 position=position
             )
             return str(role["id"])


### PR DESCRIPTION
Fluxer Roles are now correctly filled with permissions. I am not sure how Stoat handles those though so I didn't touch that.

Fluxer Roles are now not reversed anymore. Role Position is ignored during the role adding process, adding them in reverse ensures the roles positions are identical with discord.