### PR TITLE
Fix sticker sync/migration 401 on self-hosted Fluxer instances

### DIFF
--- a/src/fluxer/_lib_patches.py
+++ b/src/fluxer/_lib_patches.py
@@ -1,0 +1,85 @@
+"""Runtime fixes for bugs in the fluxer.py library.
+
+The library's guild *sticker* HTTP methods construct their routes with a bare
+``Route(...)`` instead of ``self._route(...)``. ``Route`` defaults its
+``base_url`` to the official host (``https://api.fluxer.app/v1``), so on a
+self-hosted instance these requests are sent to the wrong server and rejected
+with ``401 UNAUTHORIZED`` — even though the bot token is valid for the
+self-hosted host. The emoji methods are unaffected because they correctly use
+``self._route`` (which passes ``base_url=self.api_url``).
+
+We only patch the two methods disco-reaper actually calls
+(``get_guild_stickers`` and ``create_guild_sticker``); the other sticker
+methods are buggy too but unused, and their REST paths can't be verified here.
+
+This lives in disco-reaper rather than the vendored library so the fix survives
+``pip install -r requirements.txt`` (which reinstalls fluxer.py from git).
+
+Remove this module once https://github.com/akarealemil/fluxer.py ships the fix.
+"""
+
+import base64
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_applied = False
+
+
+def apply_fluxer_patches() -> None:
+    """Idempotently patch the broken sticker methods on fluxer's HTTPClient."""
+    global _applied
+    if _applied:
+        return
+
+    try:
+        from fluxer.http import HTTPClient
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(f"Could not import fluxer.http to apply sticker patch: {e}")
+        return
+
+    async def get_guild_stickers(self, guild_id: int | str) -> list[dict[str, Any]]:
+        # Use _route so the request targets the configured (self-hosted) api_url.
+        return await self.request(
+            self._route("GET", "/guilds/{guild_id}/stickers", guild_id=guild_id)
+        )
+
+    async def create_guild_sticker(
+        self,
+        guild_id: int | str,
+        *,
+        name: str,
+        image: bytes,
+        roles: "list[int | str] | None" = None,
+        reason: "str | None" = None,
+    ) -> dict[str, Any]:
+        image_data = base64.b64encode(image).decode("ascii")
+        if image.startswith(b"\x89PNG"):
+            mime_type = "image/png"
+        elif image.startswith(b"\xff\xd8\xff"):
+            mime_type = "image/jpeg"
+        elif image.startswith(b"GIF89a") or image.startswith(b"GIF87a"):
+            mime_type = "image/gif"
+        else:
+            mime_type = "image/png"
+
+        payload: dict[str, Any] = {
+            "name": name,
+            "image": f"data:{mime_type};base64,{image_data}",
+        }
+        if roles is not None:
+            payload["roles"] = [str(role_id) for role_id in roles]
+
+        # Use _route so the request targets the configured (self-hosted) api_url.
+        return await self.request(
+            self._route("POST", "/guilds/{guild_id}/stickers", guild_id=guild_id),
+            json=payload,
+            reason=reason,
+        )
+
+    HTTPClient.get_guild_stickers = get_guild_stickers
+    HTTPClient.create_guild_sticker = create_guild_sticker
+
+    _applied = True
+    logger.debug("Applied fluxer.py sticker route patches (self-hosted base_url fix).")

--- a/src/fluxer/writer.py
+++ b/src/fluxer/writer.py
@@ -4,7 +4,14 @@ import logging
 from typing import Optional, List, Dict, Any
 from fluxer import Bot, Webhook, Forbidden, File
 
+from src.fluxer._lib_patches import apply_fluxer_patches
+
 logger = logging.getLogger(__name__)
+
+# Fix fluxer.py's sticker methods (wrong base_url on self-hosted instances)
+# before any HTTPClient is created. See _lib_patches for details.
+apply_fluxer_patches()
+
 
 class FluxerWriter:
     def __init__(self, token: str, community_id: str, api_url: str = "default"):


### PR DESCRIPTION
## Problem

On a **self-hosted Fluxer instance**, syncing or migrating **stickers** fails with `401 UNAUTHORIZED`, even though emojis work and the bot token is valid. Example trace from sticker sync:

```
src.ui.shuttle_ops ERROR Batch Sync Error: 401 UNAUTHORIZED: Unauthorized.
  ... context.fluxer_writer.client.get_guild_stickers(...)
  fluxer/http.py ... Route("GET", "/guilds/{guild_id}/stickers", ...)
fluxer.errors.Unauthorized: 401 UNAUTHORIZED: Unauthorized.
```

## Root cause

This is a bug in the `fluxer.py` library. Its guild **sticker** HTTP methods build their route with a bare `Route(...)`, whose `base_url` defaults to the official host `https://api.fluxer.app/v1`. So on a self-hosted instance, sticker requests are sent to **api.fluxer.app** with a token that's only valid for the self-hosted host → `401`. The **emoji** methods are unaffected because they use `self._route(...)`, which passes `base_url=self.api_url`.

This affects both `get_guild_stickers` (sync) and `create_guild_sticker` (migration; its failure was previously swallowed).

## Fix

Add `src/fluxer/_lib_patches.py` with `apply_fluxer_patches()`, invoked from `writer.py` before any `HTTPClient` is created. It replaces the two sticker methods disco-reaper calls with corrected versions that use `self._route(...)` so requests target the configured `api_url`. Verified locally: both now build URLs against the configured host instead of `api.fluxer.app`.

Kept as an in-repo runtime patch (rather than editing the vendored library) so it survives `pip install -r requirements.txt`, which reinstalls `fluxer.py` from git. The underlying bug should ideally be fixed upstream in [`akarealemil/fluxer.py`](https://github.com/akarealemil/fluxer.py), after which this module can be removed.

## Scope

Only the two methods disco-reaper actually uses are patched. `get_guild_sticker` / `delete_guild_sticker` have the same bug (plus path typos) but are unused here, so they're left untouched.

---

🤖 **AI disclosure:** This change was diagnosed and written with the assistance of an LLM (Anthropic's Claude, via Claude Code), against real self-hosted migration logs, and verified locally. Please review before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed guild sticker operations on self-hosted instances. Creating and retrieving guild stickers now properly route requests through your configured host environment instead of using incorrect default paths, ensuring sticker management functionality works correctly in self-hosted deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->